### PR TITLE
Add short descriptions for the brick & wall type

### DIFF
--- a/src/basic.lean
+++ b/src/basic.lean
@@ -1,3 +1,7 @@
+/-
+Define brick as the type of the generating tangles.
+-/
+
 inductive brick : Type
 | Vert : brick
 | Cap : brick
@@ -26,6 +30,9 @@ def brick.codomain : brick → ℕ
 instance brick_has_decidable_eq : decidable_eq brick := by tactic.mk_dec_eq_instance
 @[simp] def bricks.count (bs : list brick) (b0 : brick) : ℕ := list.length (list.filter (eq b0) bs)
 
+/-
+Define wall as a vertically-arranged collection of collections of horizontally-arraged bricks.
+-/
 def wall : Type := list (list brick)
 
 @[simp] def wall.count (w : wall) (b0 : brick): ℕ := list.foldr nat.add 0 (list.map (λ bs, bricks.count bs b0) w)


### PR DESCRIPTION
I searched for knot theory formalization in Lean and found your repo.

Beeing a novice in knot theory it took me some time to find other resources using the "brick/wall" representation. Eventually I realized there is
- Prathamesh, T. V. H. (2015). Formalising Knot Theory in Isabelle/HOL. Lecture Notes in Computer Science, 438–452. [doi:10.1007/978-3-319-22102-1_29](https://dx.doi.org/10.1007/978-3-319-22102-1_29) / [prathamesh-t/Tangle-Isabelle](https://github.com/prathamesh-t/Tangle-Isabelle/)

following the definitions of 
- Sawin, S.: Links, quantum groups and TQFTs. Bull. Amer. Math. Soc. (N.S.) 33, 413–445 (1996) [doi:10.1090/S0273-0979-96-00690-8](https://doi.org/10.1090/S0273-0979-96-00690-8)

which are based on Tur88/Tur89/Fy89
- P. Freyd and D. Yetter. Braided compact closed categories with applications to low-
dimensional topology. Adv. in Math., 77(2):156–182, 1989. MR 91c:57019 [doi:10.1016/0001-8708(89)90018-2](https://doi.org/10.1016/0001-8708(89)90018-2)

I did not want to put those references in the text myself but instead just added two short descriptions so that finding those resources might be easier for others.

Thank you for publishing this repository!